### PR TITLE
remove services that are no longer accessible. fixes #79

### DIFF
--- a/backend/configuration.php
+++ b/backend/configuration.php
@@ -3,5 +3,5 @@
 // install_location is the installation directory
 // see also frontend/configuration.js
 //
-$install_location = "https://stage.sofiadigital.fi/dvb/dvb-i-reference-application";
+$install_location = "http://paulhiggs.ddns.net:8877/pauls";
 ?>

--- a/backend/servicelists/TM-STREAM0075r1 DVB-DASH_Reference_Streams.xml
+++ b/backend/servicelists/TM-STREAM0075r1 DVB-DASH_Reference_Streams.xml
@@ -6,34 +6,34 @@
 	<Name>DVB-DASH Reference Streams</Name>
 	<ProviderName>DVB</ProviderName>
 	<!-- see http://dvb-2017-dm.s3.eu-central-1.amazonaws.com/overview.html -->
-	
+
 	<LCNTableList>
 		<LCNTable>
-			<LCN channelNumber="100" serviceRef="tag:dvb.org,2020:Unified-0"/>
-			<LCN channelNumber="1" serviceRef="tag:dvb.org,2020:Unified-1"/>
-			<LCN channelNumber="2" serviceRef="tag:dvb.org,2020:Unified-2"/>
-			<LCN channelNumber="3" serviceRef="tag:dvb.org,2020:Unified-3"/>
-			<LCN channelNumber="4" serviceRef="tag:dvb.org,2020:Unified-4"/>
-			<LCN channelNumber="7" serviceRef="tag:dvb.org,2020:Unified-7"/>
-			<LCN channelNumber="8" serviceRef="tag:dvb.org,2020:Unified-8"/>
-			<LCN channelNumber="11" serviceRef="tag:dvb.org,2020:Unified-mt"/>
+<!--			<LCN channelNumber="1" serviceRef="tag:dvb.org,2020:Unified-1"/> -->
+<!--			<LCN channelNumber="2" serviceRef="tag:dvb.org,2020:Unified-2"/> -->
+<!--			<LCN channelNumber="3" serviceRef="tag:dvb.org,2020:Unified-3"/> -->
+<!--			<LCN channelNumber="4" serviceRef="tag:dvb.org,2020:Unified-4"/> -->
+<!--			<LCN channelNumber="7" serviceRef="tag:dvb.org,2020:Unified-7"/> -->
+<!--			<LCN channelNumber="8" serviceRef="tag:dvb.org,2020:Unified-8"/> -->
+<!--			<LCN channelNumber="11" serviceRef="tag:dvb.org,2020:Unified-mt"/> -->
 			<LCN channelNumber="21" serviceRef="tag:dvb.org,2020:DASHIF-LL"/>
-			<LCN channelNumber="22" serviceRef="tag:dvb.org,2020:HARMONIC-LL"/>
+<!--			<LCN channelNumber="22" serviceRef="tag:dvb.org,2020:HARMONIC-LL"/> -->
 			<LCN channelNumber="23" serviceRef="tag:dvb.org,2020:AKAMAI-LL"/>
-			<LCN channelNumber="24" serviceRef="tag:dvb.org,2020:UNIFIED-LL"/>
-			<LCN channelNumber="31" serviceRef="tag:dvb.org,2020:DOLBY-HDR"/>
-			<LCN channelNumber="32" serviceRef="tag:dvb.org,2020:PHILIPS-HDR"/>
-			<LCN channelNumber="33" serviceRef="tag:dvb.org,2020:SES-HDR-1"/>
-			<LCN channelNumber="34" serviceRef="tag:dvb.org,2020:SES-HDR-2"/>
+<!--			<LCN channelNumber="24" serviceRef="tag:dvb.org,2020:UNIFIED-LL"/> -->
+<!--			<LCN channelNumber="31" serviceRef="tag:dvb.org,2020:DOLBY-HDR"/> -->
+<!--			<LCN channelNumber="32" serviceRef="tag:dvb.org,2020:PHILIPS-HDR"/> -->
+<!--			<LCN channelNumber="33" serviceRef="tag:dvb.org,2020:SES-HDR-1"/> -->
+<!--			<LCN channelNumber="34" serviceRef="tag:dvb.org,2020:SES-HDR-2"/> -->
 			<LCN channelNumber="41" serviceRef="tag:dvb.org,2020:CMAF-1"/>
 			<LCN channelNumber="42" serviceRef="tag:dvb.org,2020:CMAF-2"/>
 			<LCN channelNumber="43" serviceRef="tag:dvb.org,2020:CMAF-3"/>
+<!--			<LCN channelNumber="100" serviceRef="tag:dvb.org,2020:Unified-0"/> -->
 		</LCNTable>
 	</LCNTableList>
   <ContentGuideSource CGSID="cgid-1">
     <ProviderName>DVB-I Reference Application</ProviderName>
     <ScheduleInfoEndpoint contentType="application/xml">
-      <URI>INSTALL--LOCATION/backend/schedule.php</URI>
+      <URI>INSTALL~~LOCATION/backend/schedule.php</URI>
     </ScheduleInfoEndpoint>
   </ContentGuideSource>
 	<Service version="1">
@@ -61,7 +61,7 @@
 		<ServiceName>Live Clear</ServiceName>
 		<ProviderName>Unified Streaming</ProviderName>
 	</Service>
-	
+
 	<Service version="1">
 		<UniqueIdentifier>tag:dvb.org,2020:Unified-1</UniqueIdentifier>
 		<ServiceInstance>
@@ -78,7 +78,7 @@
 			<ContentAttributes>
 				<AudioAttributes>
 					<tva:Coding href="urn:mpeg:mpeg7:cs:AudioCodingFormatCS:2001:4.3.1"/> <!-- mp4a.40.2 == Low Complexity AAC -->
-					<tva:NumOfChannels>1</tva:NumOfChannels> <!-- <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="1"/> -->
+					<tva:NumOfChannels>1</tva:NumOfChannels>
 					<tva:SampleFrequency>48000</tva:SampleFrequency>
 				</AudioAttributes>
 				<VideoAttributes>
@@ -87,7 +87,7 @@
 					<tva:VerticalSize>720</tva:VerticalSize>
 					<tva:FrameRate>25</tva:FrameRate>
 				</VideoAttributes>
-			</ContentAttributes> 
+			</ContentAttributes>
 			<DASHDeliveryParameters>
 				<UriBasedLocation contentType="application/dash+xml">
 					<URI>https://pl8q5ug7b6.execute-api.eu-central-1.amazonaws.com/1.mpd</URI>
@@ -153,7 +153,7 @@
 					<tva:VerticalSize>720</tva:VerticalSize>
 					<tva:FrameRate>25</tva:FrameRate>
 				</VideoAttributes>
-			</ContentAttributes> 
+			</ContentAttributes>
 			<DASHDeliveryParameters>
 				<UriBasedLocation contentType="application/dash+xml">
 					<URI>https://pl8q5ug7b6.execute-api.eu-central-1.amazonaws.com/3.mpd</URI>
@@ -163,7 +163,7 @@
 		<ServiceName>Live 'cbcs' with ads</ServiceName>
 		<ProviderName>Unified Streaming</ProviderName>
 	</Service>
-	
+
 	<Service version="1">
 		<UniqueIdentifier>tag:dvb.org,2020:Unified-4</UniqueIdentifier>
 		<ServiceInstance>
@@ -179,7 +179,7 @@
 					<tva:VerticalSize>200</tva:VerticalSize>
 					<tva:FrameRate>24</tva:FrameRate>
 				</VideoAttributes>
-				<!-- UNSPECIFIED WVTT -> contentType="text" codecs="wvtt" lang="en" 
+				<!-- UNSPECIFIED WVTT -> contentType="text" codecs="wvtt" lang="en"
 				<CaptionLanguage>en</CaptionLanguage> -->
 				<!-- TTML ->  contentType="text" lang="en" codecs="stpp.ttml.im1t"-->
 				<CaptionLanguage>en</CaptionLanguage>
@@ -193,7 +193,7 @@
 		<ServiceName>ToS Live Clear subtitles, ads</ServiceName>
 		<ProviderName>Unified Streaming</ProviderName>
 	</Service>
-	
+
 	<Service version="1">
 		<UniqueIdentifier>tag:dvb.org,2020:Unified-7</UniqueIdentifier>
 		<ServiceInstance>
@@ -219,7 +219,7 @@
 		<ServiceName>Live clear, ads inserted</ServiceName>
 		<ProviderName>Unified Streaming</ProviderName>
 	</Service>
-	
+
 	<Service version="1">
 		<UniqueIdentifier>tag:dvb.org,2020:Unified-8</UniqueIdentifier>
 		<ServiceInstance>
@@ -245,7 +245,7 @@
 					<tva:VerticalSize>720</tva:VerticalSize>
 					<tva:FrameRate>25</tva:FrameRate>
 				</VideoAttributes>
-			</ContentAttributes> 
+			</ContentAttributes>
 			<DASHDeliveryParameters>
 				<UriBasedLocation contentType="application/dash+xml">
 					<URI>https://pl8q5ug7b6.execute-api.eu-central-1.amazonaws.com/8.mpd</URI>
@@ -281,7 +281,7 @@
 		<ServiceName>Live clear,ads via AWS MT</ServiceName>
 		<ProviderName>Unified Streaming</ProviderName>
 	</Service>
-	
+
 	<Service version="1">
 		<UniqueIdentifier>tag:dvb.org,2020:DASHIF-LL</UniqueIdentifier>
 		<ServiceInstance>
@@ -319,7 +319,7 @@
 		<ServiceName>DASH-IF livesim LL</ServiceName>
  		<ProviderName>DASH Industry Forum</ProviderName>
 	</Service>
-	
+
 	<Service version="1">
 		<UniqueIdentifier>tag:dvb.org,2020:HARMONIC-LL</UniqueIdentifier>
 		<ServiceInstance>
@@ -353,7 +353,7 @@
 		<ServiceName>Harmonic LL test</ServiceName>
  		<ProviderName>Harmonic</ProviderName>
 	</Service>
-	
+
 	<Service version="1">
 		<UniqueIdentifier>tag:dvb.org,2020:AKAMAI-LL</UniqueIdentifier>
 		<ServiceInstance>
@@ -362,7 +362,7 @@
 					<tva:Coding href="urn:mpeg:mpeg7:cs:AudioCodingFormatCS:2001:4.3.1"/> <!-- mp4a.40.2 == Low Complexity AAC -->
 					<tva:NumOfChannels>2</tva:NumOfChannels> <!-- <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/> -->
 					<tva:SampleFrequency>48000</tva:SampleFrequency>
-				</AudioAttributes>				
+				</AudioAttributes>
 				<VideoAttributes>
 					<tva:Coding href="urn:dvb:metadata:cs:VideoCodecCS:2007:1.4.10"/><!-- "avc1.64001F" == MPEG-4 AVC High profile level 3.1 -->
 					<tva:HorizontalSize>1280</tva:HorizontalSize>
@@ -379,7 +379,7 @@
 		<ServiceName>Akamai LL test</ServiceName>
  		<ProviderName>Akamai</ProviderName>
 	</Service>
-	
+
 	<Service version="1">
 		<UniqueIdentifier>tag:dvb.org,2020:UNIFIED-LL</UniqueIdentifier>
 		<ServiceInstance>
@@ -388,7 +388,7 @@
 					<tva:Coding href="urn:mpeg:mpeg7:cs:AudioCodingFormatCS:2001:4.3.1"/> <!-- mp4a.40.2 == Low Complexity AAC -->
 					<tva:NumOfChannels>1</tva:NumOfChannels> <!-- <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="1"/> -->
 					<tva:SampleFrequency>48000</tva:SampleFrequency>
-				</AudioAttributes>				
+				</AudioAttributes>
 				<VideoAttributes>
 					<tva:Coding href="urn:dvb:metadata:cs:VideoCodecCS:2007:1.4.10"/><!-- "avc1.64001F" == MPEG-4 AVC High profile level 3.1 -->
 					<tva:HorizontalSize>1280</tva:HorizontalSize>
@@ -404,8 +404,8 @@
 		</ServiceInstance>
 		<ServiceName>Unified Streaming LL test</ServiceName>
  		<ProviderName>Unified Streaming</ProviderName>
-	</Service>	
-	
+	</Service>
+
 	<Service version="1">
 		<UniqueIdentifier>tag:dvb.org,2020:DOLBY-HDR</UniqueIdentifier>
 		<ServiceInstance>
@@ -415,14 +415,14 @@
 					<tva:NumOfChannels>2</tva:NumOfChannels> <!-- <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/> -->
 					<tva:AudioLanguage>en</tva:AudioLanguage>
 					<tva:SampleFrequency>48000</tva:SampleFrequency>
-				</AudioAttributes>				
+				</AudioAttributes>
 				<VideoAttributes>
 					<tva:Coding href="urn:dvb:metadata:cs:VideoCodecCS:2021:4.2.16"/><!-- "hev1.2.4.L153.B0" == High Efficiency Video Coding Main 10 Profile Main Tier L5.1  -->
 					<tva:HorizontalSize>3840</tva:HorizontalSize>
 					<tva:VerticalSize>2160</tva:VerticalSize>
 					<tva:FrameRate>50</tva:FrameRate>
 				</VideoAttributes>
-				<!-- UNSPECIFIED 
+				<!-- UNSPECIFIED
 					<EssentialProperty schemeIdUri="urn:mpeg:mpegB:cicp:ColourPrimaries" value="9"></EssentialProperty>
 					<EssentialProperty schemeIdUri="urn:mpeg:mpegB:cicp:TransferCharacteristics" value="16"></EssentialProperty>
 					<EssentialProperty schemeIdUri="urn:mpeg:mpegB:cicp:MatrixCoefficients" value="9"></EssentialProperty>
@@ -437,8 +437,8 @@
 		</ServiceInstance>
 		<ServiceName> Dolby HDR DM</ServiceName>
  		<ProviderName>Dolby</ProviderName>
-	</Service>	
-	
+	</Service>
+
 	<Service version="1">
 		<UniqueIdentifier>tag:dvb.org,2020:PHILIPS-HDR</UniqueIdentifier>
 		<ServiceInstance>
@@ -448,14 +448,14 @@
 					<tva:NumOfChannels>2</tva:NumOfChannels> <!-- <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/> -->
 					<tva:AudioLanguage>en</tva:AudioLanguage>
 					<tva:SampleFrequency>48000</tva:SampleFrequency>
-				</AudioAttributes>				
+				</AudioAttributes>
 				<VideoAttributes>
 					<tva:Coding href="urn:dvb:metadata:cs:VideoCodecCS:2021:4.2.16"/><!-- "hev1.2.4.L153.B0" == High Efficiency Video Coding Main 10 Profile Main Tier L5.1  -->
 					<tva:HorizontalSize>3840</tva:HorizontalSize>
 					<tva:VerticalSize>2160</tva:VerticalSize>
 					<tva:FrameRate>50</tva:FrameRate>
 				</VideoAttributes>
-				<!-- UNSPECIFIED 
+				<!-- UNSPECIFIED
 					<EssentialProperty schemeIdUri="urn:mpeg:mpegB:cicp:ColourPrimaries" value="9"></EssentialProperty>
 					<EssentialProperty schemeIdUri="urn:mpeg:mpegB:cicp:TransferCharacteristics" value="16"></EssentialProperty>
 					<EssentialProperty schemeIdUri="urn:mpeg:mpegB:cicp:MatrixCoefficients" value="9"></EssentialProperty>
@@ -470,8 +470,8 @@
 		</ServiceInstance>
 		<ServiceName>Philips HDR DM</ServiceName>
  		<ProviderName>Philips</ProviderName>
-	</Service>	
-	
+	</Service>
+
 	<Service version="1">
 		<UniqueIdentifier>tag:dvb.org,2020:SES-HDR-1</UniqueIdentifier>
 		<ServiceInstance>
@@ -481,14 +481,14 @@
 					<tva:NumOfChannels>2</tva:NumOfChannels> <!-- <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/> -->
 					<tva:AudioLanguage>en</tva:AudioLanguage>
 					<tva:SampleFrequency>48000</tva:SampleFrequency>
-				</AudioAttributes>				
+				</AudioAttributes>
 				<VideoAttributes>
 					<tva:Coding href="urn:dvb:metadata:cs:VideoCodecCS:2021:4.2.16"/><!-- "hev1.2.4.L153.B0" == High Efficiency Video Coding Main 10 Profile Main Tier L5.1  -->
 					<tva:HorizontalSize>3840</tva:HorizontalSize>
 					<tva:VerticalSize>2160</tva:VerticalSize>
 					<tva:FrameRate>50</tva:FrameRate>
 				</VideoAttributes>
-				<!-- UNSPECIFIED 
+				<!-- UNSPECIFIED
 					<EssentialProperty schemeIdUri="urn:mpeg:mpegB:cicp:ColourPrimaries" value="9"></EssentialProperty>
 					<EssentialProperty schemeIdUri="urn:mpeg:mpegB:cicp:TransferCharacteristics" value="16"></EssentialProperty>
 					<EssentialProperty schemeIdUri="urn:mpeg:mpegB:cicp:MatrixCoefficients" value="9"></EssentialProperty>
@@ -503,8 +503,8 @@
 		</ServiceInstance>
 		<ServiceName>SES HDR DM using SL-HDR2 SEI messages</ServiceName>
  		<ProviderName>SES</ProviderName>
-	</Service>	
-	
+	</Service>
+
 	<Service version="1">
 		<UniqueIdentifier>tag:dvb.org,2020:SES-HDR-2</UniqueIdentifier>
 		<ServiceInstance>
@@ -514,14 +514,14 @@
 					<tva:NumOfChannels>2</tva:NumOfChannels> <!-- <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/> -->
 					<tva:AudioLanguage>en</tva:AudioLanguage>
 					<tva:SampleFrequency>48000</tva:SampleFrequency>
-				</AudioAttributes>				
+				</AudioAttributes>
 				<VideoAttributes>
 					<tva:Coding href="urn:dvb:metadata:cs:VideoCodecCS:2021:4.2.16"/><!-- "hev1.2.4.L153.B0" == High Efficiency Video Coding Main 10 Profile Main Tier L5.1  -->
 					<tva:HorizontalSize>3840</tva:HorizontalSize>
 					<tva:VerticalSize>2160</tva:VerticalSize>
 					<tva:FrameRate>50</tva:FrameRate>
 				</VideoAttributes>
-				<!-- UNSPECIFIED 
+				<!-- UNSPECIFIED
 					<EssentialProperty schemeIdUri="urn:mpeg:mpegB:cicp:ColourPrimaries" value="9"></EssentialProperty>
 					<EssentialProperty schemeIdUri="urn:mpeg:mpegB:cicp:TransferCharacteristics" value="16"></EssentialProperty>
 					<EssentialProperty schemeIdUri="urn:mpeg:mpegB:cicp:MatrixCoefficients" value="9"></EssentialProperty>
@@ -536,8 +536,8 @@
 		</ServiceInstance>
 		<ServiceName>SES HDR DM using 2094-10 SEI messages</ServiceName>
  		<ProviderName>SES</ProviderName>
-	</Service>	
-	
+	</Service>
+
 	<Service version="1">
 		<UniqueIdentifier>tag:dvb.org,2020:CMAF-1</UniqueIdentifier>
 		<ServiceInstance>
@@ -548,7 +548,7 @@
 					<tva:AudioLanguage>en</tva:AudioLanguage>
 					<tva:SampleFrequency>48000</tva:SampleFrequency>
 					<tva:BitRate>64349</tva:BitRate>
-				</AudioAttributes>				
+				</AudioAttributes>
 				<AudioAttributes>
 					<tva:Coding href="urn:mpeg:mpeg7:cs:AudioCodingFormatCS:2001:4.3.1"/> <!-- mp4a.40.2 == Low Complexity AAC -->
 					<tva:NumOfChannels>2</tva:NumOfChannels> <!-- <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/> -->
@@ -577,7 +577,7 @@
 					<tva:FrameRate>24</tva:FrameRate>
 					<tva:BitRate>1600000</tva:BitRate>
 				</VideoAttributes>
-			<!-- UNSPECIFIED WVTT -> contentType="text" codecs="wvtt" lang="en" 
+			<!-- UNSPECIFIED WVTT -> contentType="text" codecs="wvtt" lang="en"
 				<CaptionLanguage>en</CaptionLanguage>
 			UNSPECIFIED WVTT -> contentType="text" codecs="wvtt" lang="de"
 				<CaptionLanguage>de</CaptionLanguage>
@@ -606,7 +606,7 @@
 		</ServiceInstance>
 		<ServiceName>Tears of steel HEVC</ServiceName>
  		<ProviderName>MPEG</ProviderName>
-	</Service>	
+	</Service>
 
 
 	<Service version="1">
@@ -619,7 +619,7 @@
 					<tva:AudioLanguage>en</tva:AudioLanguage>
 					<tva:SampleFrequency>48000</tva:SampleFrequency>
 					<tva:BitRate>64349</tva:BitRate>
-				</AudioAttributes>				
+				</AudioAttributes>
 				<AudioAttributes>
 					<tva:Coding href="urn:mpeg:mpeg7:cs:AudioCodingFormatCS:2001:4.3.1"/> <!-- mp4a.40.2 == Low Complexity AAC -->
 					<tva:NumOfChannels>2</tva:NumOfChannels> <!-- <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/> -->
@@ -677,8 +677,8 @@
 		</ServiceInstance>
 		<ServiceName>Tears of steel, ttml/mp4 subtitles</ServiceName>
  		<ProviderName>MPEG</ProviderName>
-	</Service>	
-	
+	</Service>
+
 	<Service version="1">
 		<UniqueIdentifier>tag:dvb.org,2020:CMAF-3</UniqueIdentifier>
 		<ServiceInstance>
@@ -689,7 +689,7 @@
 					<tva:AudioLanguage>en</tva:AudioLanguage>
 					<tva:SampleFrequency>48000</tva:SampleFrequency>
 					<tva:BitRate>64349</tva:BitRate>
-				</AudioAttributes>				
+				</AudioAttributes>
 				<AudioAttributes>
 					<tva:Coding href="urn:mpeg:mpeg7:cs:AudioCodingFormatCS:2001:4.3.1"/> <!-- mp4a.40.2 == Low Complexity AAC -->
 					<tva:NumOfChannels>2</tva:NumOfChannels> <!-- <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/> -->
@@ -708,25 +708,25 @@
 					<tva:HorizontalSize>448</tva:HorizontalSize>
 					<tva:VerticalSize>200</tva:VerticalSize>
 					<tva:BitRate>759000</tva:BitRate>
-				</VideoAttributes>				
+				</VideoAttributes>
 				<VideoAttributes>
 					<tva:Coding href="urn:dvb:metadata:cs:VideoCodecCS:2007:1.4.10"/><!-- "avc1.64001F" == MPEG-4 AVC High profile level 3.1 -->
 					<tva:HorizontalSize>784</tva:HorizontalSize>
 					<tva:VerticalSize>350</tva:VerticalSize>
 					<tva:BitRate>1026000</tva:BitRate>
-				</VideoAttributes>			
+				</VideoAttributes>
 				<VideoAttributes>
 					<tva:Coding href="urn:dvb:metadata:cs:VideoCodecCS:2007:1.4.12"/><!-- "avc1.640028" == MPEG-4 AVC High profile level 4.0 -->
 					<tva:HorizontalSize>1680</tva:HorizontalSize>
 					<tva:VerticalSize>750</tva:VerticalSize>
 					<tva:BitRate>1501000</tva:BitRate>
-				</VideoAttributes>					
+				</VideoAttributes>
 				<VideoAttributes>
 					<tva:Coding href="urn:dvb:metadata:cs:VideoCodecCS:2007:1.4.12"/><!-- "avc1.640028" == MPEG-4 AVC High profile level 4.0 -->
 					<tva:HorizontalSize>1680</tva:HorizontalSize>
 					<tva:VerticalSize>750</tva:VerticalSize>
 					<tva:BitRate>2205000</tva:BitRate>
-				</VideoAttributes>					
+				</VideoAttributes>
 			<!-- UNSPECIFIED WVTT -> mimeType="application/mp4" codecs="wvtt" lang="en"
 				<CaptionLanguage>en</CaptionLanguage>
 			UNSPECIFIED WVTT -> mimeType="application/mp4" codecs="wvtt" lang="de"
@@ -757,6 +757,6 @@
 		<ServiceName>Tears of steel,vtt/mp4 subtitles</ServiceName>
  		<ProviderName>MPEG</ProviderName>
 	</Service>
-	
-	
+
+
 </ServiceList>

--- a/backend/servicelists/drm.xml
+++ b/backend/servicelists/drm.xml
@@ -10,7 +10,7 @@
   <ContentGuideSource CGSID="cgid-1">
     <ProviderName>DVB-I Reference Application</ProviderName>
     <ScheduleInfoEndpoint contentType="application/xml">
-      <URI>INSTALL--LOCATION/backend/schedule.php</URI>
+      <URI>INSTALL~~LOCATION/backend/schedule.php</URI>
     </ScheduleInfoEndpoint>
   </ContentGuideSource>
   <Service version="1">
@@ -24,7 +24,7 @@
       <SourceType>urn:dvb:metadata:source:dvb-dash</SourceType>
       <DASHDeliveryParameters>
         <UriBasedLocation contentType="application/dash+xml">
-          <URI>INSTALL--LOCATION/drm/manifest.mpd</URI>
+          <URI>INSTALL~~LOCATION/drm/manifest.mpd</URI>
         </UriBasedLocation>
       </DASHDeliveryParameters>
     </ServiceInstance>
@@ -37,7 +37,7 @@
      <RelatedMaterial>
       <HowRelated href="urn:dvb:metadata:cs:LinkedApplicationCS:2019:1.2"/>
       <MediaLocator>
-        <tva:MediaUri contentType="application/xhtml+xml">INSTALL--LOCATION/linked_applications/android_drm_widevine.html</tva:MediaUri>
+        <tva:MediaUri contentType="application/xhtml+xml">INSTALL~~LOCATION/linked_applications/android_drm_widevine.html</tva:MediaUri>
       </MediaLocator>
     </RelatedMaterial>
       <ContentProtection>
@@ -61,7 +61,7 @@
       <RelatedMaterial>
        <HowRelated href="urn:dvb:metadata:cs:LinkedApplicationCS:2019:1.2"/>
        <MediaLocator>
-        <tva:MediaUri contentType="application/vnd.dvb.ait+xml">INSTALL--LOCATION/linked_applications/hbbtv_playready_aitx.php</tva:MediaUri>
+        <tva:MediaUri contentType="application/vnd.dvb.ait+xml">INSTALL~~LOCATION/linked_applications/hbbtv_playready_aitx.php</tva:MediaUri>
        </MediaLocator>
       </RelatedMaterial>
       <ContentProtection>

--- a/backend/servicelists/example.xml
+++ b/backend/servicelists/example.xml
@@ -7,18 +7,21 @@
       <LCN channelNumber="647" serviceRef="tag:dvb.org,2020:sid1"/>
       <LCN channelNumber="11" serviceRef="tag:dvb.org,2020:sid2"/>
       <LCN channelNumber="4" serviceRef="tag:dvb.org,2020:sid3"/>
-      <LCN channelNumber="8" serviceRef="tag:dvb.org,2020:sid5"/>
-      <LCN channelNumber="12" serviceRef="tag:dvb.org,2020:sid6"/>
-      <LCN channelNumber="34" serviceRef="tag:dvb.org,2020:sid7"/>
-      <LCN channelNumber="324" serviceRef="tag:dvb.org,2020:sid8"/>
-      <LCN channelNumber="642" serviceRef="tag:dvb.org,2020:sid9"/>
-      <LCN channelNumber="640" serviceRef="tag:dvb.org,2020:sid10"/>
-      <LCN channelNumber="641" serviceRef="tag:dvb.org,2020:sid11"/>
-      <LCN channelNumber="643" serviceRef="tag:dvb.org,2020:sid12"/>
-      <LCN channelNumber="644" serviceRef="tag:dvb.org,2020:sid13"/>
-      <LCN channelNumber="645" serviceRef="tag:dvb.org,2020:sid14"/>
-      <LCN channelNumber="5" serviceRef="tag:dvb.org,2020:sid16"/>
-      <LCN channelNumber="6" serviceRef="tag:dvb.org,2020:sid17"/>
+<!--      <LCN channelNumber="8" serviceRef="tag:dvb.org,2020:sid5"/> -->
+<!--      <LCN channelNumber="12" serviceRef="tag:dvb.org,2020:sid6"/> -->
+<!--      <LCN channelNumber="34" serviceRef="tag:dvb.org,2020:sid7"/> -->
+<!--      <LCN channelNumber="324" serviceRef="tag:dvb.org,2020:sid8"/> -->
+<!--      <LCN channelNumber="642" serviceRef="tag:dvb.org,2020:sid9"/> -->
+<!--      <LCN channelNumber="640" serviceRef="tag:dvb.org,2020:sid10"/> -->
+<!--      <LCN channelNumber="641" serviceRef="tag:dvb.org,2020:sid11"/> -->
+<!--      <LCN channelNumber="643" serviceRef="tag:dvb.org,2020:sid12"/> -->
+<!--      <LCN channelNumber="644" serviceRef="tag:dvb.org,2020:sid13"/> -->
+<!--      <LCN channelNumber="645" serviceRef="tag:dvb.org,2020:sid14"/>-->
+<!--      <LCN channelNumber="5" serviceRef="tag:dvb.org,2020:sid16"/> -->
+<!--      <LCN channelNumber="6" serviceRef="tag:dvb.org,2020:sid17"/> -->
+      <LCN channelNumber="647" serviceRef="tag:dvb.org,2020:sid15"/>
+      <LCN channelNumber="648" serviceRef="tag:dvb.org,2020:sid18"/>
+
     </LCNTable>
   </LCNTableList>
   <ContentGuideSource CGSID="cgid-1">
@@ -74,7 +77,7 @@
     <ProviderName>IRT</ProviderName>
     <ContentGuideServiceRef>cgsid_3</ContentGuideServiceRef>
   </Service>
-  <Service version="1">
+<!--  <Service version="1">
     <UniqueIdentifier>tag:dvb.org,2020:sid5</UniqueIdentifier>
     <ServiceInstance priority="2">
       <SourceType>urn:dvb:metadata:source:dvb-dash</SourceType>
@@ -94,8 +97,8 @@
       </MediaLocator>
     </RelatedMaterial>
     <ContentGuideServiceRef>cgsid_5</ContentGuideServiceRef>
-  </Service>
-  <Service version="1">
+  </Service> -->
+<!--  <Service version="1">
     <UniqueIdentifier>tag:dvb.org,2020:sid6</UniqueIdentifier>
     <ServiceInstance priority="1">
       <SourceType>urn:dvb:metadata:source:dvb-dash</SourceType>
@@ -114,8 +117,8 @@
       </MediaLocator>
     </RelatedMaterial>
     <ContentGuideServiceRef>cgsid_6</ContentGuideServiceRef>
-  </Service>
-  <Service version="1">
+  </Service> -->
+<!--  <Service version="1">
     <UniqueIdentifier>tag:dvb.org,2020:sid7</UniqueIdentifier>
     <ServiceInstance priority="1">
       <SourceType>urn:dvb:metadata:source:dvb-dash</SourceType>
@@ -134,8 +137,8 @@
       </MediaLocator>
     </RelatedMaterial>
     <ContentGuideServiceRef>cgsid_7</ContentGuideServiceRef>
-  </Service>
-  <Service version="1">
+  </Service> -->
+ <!-- <Service version="1">
     <UniqueIdentifier>tag:dvb.org,2020:sid8</UniqueIdentifier>
     <ServiceInstance priority="1">
       <SourceType>urn:dvb:metadata:source:dvb-dash</SourceType>
@@ -154,8 +157,8 @@
       </MediaLocator>
     </RelatedMaterial>
     <ContentGuideServiceRef>cgsid_8</ContentGuideServiceRef>
-  </Service>
-  <Service version="1">
+  </Service> -->
+<!--  <Service version="1">
     <UniqueIdentifier>tag:dvb.org,2020:sid9</UniqueIdentifier>
     <ServiceInstance priority="1">
       <SourceType>urn:dvb:metadata:source:dvb-dash</SourceType>
@@ -174,8 +177,8 @@
       </MediaLocator>
     </RelatedMaterial>
     <ContentGuideServiceRef>cgsid_9</ContentGuideServiceRef>
-  </Service>
-  <Service version="1">
+  </Service> -->
+<!--  <Service version="1">
     <UniqueIdentifier>tag:dvb.org,2020:sid10</UniqueIdentifier>
     <ServiceInstance priority="1">
       <SourceType>urn:dvb:metadata:source:dvb-dash</SourceType>
@@ -194,8 +197,8 @@
       </MediaLocator>
     </RelatedMaterial>
     <ContentGuideServiceRef>cgsid_10</ContentGuideServiceRef>
-  </Service>
-  <Service version="1">
+  </Service> -->
+<!--  <Service version="1">
     <UniqueIdentifier>tag:dvb.org,2020:sid11</UniqueIdentifier>
     <ServiceInstance priority="1">
       <SourceType>urn:dvb:metadata:source:dvb-dash</SourceType>
@@ -214,8 +217,8 @@
       </MediaLocator>
     </RelatedMaterial>
     <ContentGuideServiceRef>cgsid_11</ContentGuideServiceRef>
-  </Service>
-  <Service version="1">
+  </Service> -->
+<!--  <Service version="1">
     <UniqueIdentifier>tag:dvb.org,2020:sid12</UniqueIdentifier>
     <ServiceInstance priority="1">
       <SourceType>urn:dvb:metadata:source:dvb-dash</SourceType>
@@ -234,8 +237,8 @@
       </MediaLocator>
     </RelatedMaterial>
     <ContentGuideServiceRef>cgsid_12</ContentGuideServiceRef>
-  </Service>
-  <Service version="1">
+  </Service> -->
+<!--  <Service version="1">
     <UniqueIdentifier>tag:dvb.org,2020:sid13</UniqueIdentifier>
     <ServiceInstance priority="1">
       <SourceType>urn:dvb:metadata:source:dvb-dash</SourceType>
@@ -254,8 +257,8 @@
       </MediaLocator>
     </RelatedMaterial>
     <ContentGuideServiceRef>cgsid_13</ContentGuideServiceRef>
-  </Service>
-  <Service version="1">
+  </Service> -->
+<!--  <Service version="1">
     <UniqueIdentifier>tag:dvb.org,2020:sid14</UniqueIdentifier>
     <ServiceInstance priority="1">
       <SourceType>urn:dvb:metadata:source:dvb-dash</SourceType>
@@ -274,7 +277,7 @@
       </MediaLocator>
     </RelatedMaterial>
     <ContentGuideServiceRef>cgsid_14</ContentGuideServiceRef>
-  </Service>
+  </Service> -->
   <Service version="1">
     <UniqueIdentifier>tag:dvb.org,2020:sid15</UniqueIdentifier>
     <ServiceInstance priority="2">
@@ -373,7 +376,7 @@
     <ProviderName>DVB</ProviderName>
     <ContentGuideServiceRef>cgsid_14</ContentGuideServiceRef>
   </Service>
-  <Service version="1">
+  <!-- <Service version="1">
     <UniqueIdentifier>tag:dvb.org,2020:sid16</UniqueIdentifier>
     <ServiceInstance priority="1">
       <SourceType>urn:dvb:metadata:source:dvb-dash</SourceType>
@@ -386,8 +389,8 @@
     <ServiceName>DVB EBU DASH</ServiceName>
     <ProviderName>DVB</ProviderName>
     <ContentGuideServiceRef>cgsid_16</ContentGuideServiceRef>
-  </Service>
-  <Service version="1">
+  </Service> -->
+<!--  <Service version="1">
     <UniqueIdentifier>tag:dvb.org,2020:sid17</UniqueIdentifier>
     <ServiceInstance priority="1">
       <SourceType>urn:dvb:metadata:source:dvb-dash</SourceType>
@@ -400,7 +403,7 @@
     <ServiceName>DVB EBU Low latency DASH</ServiceName>
     <ProviderName>DVB</ProviderName>
     <ContentGuideServiceRef>cgsid_17</ContentGuideServiceRef>
-  </Service>
+  </Service> -->
   <Service version="11">
     <UniqueIdentifier>tag:dvb.org,2020:sid18</UniqueIdentifier>
     <ServiceInstance priority="1">

--- a/backend/servicelists/example_rev1.xml
+++ b/backend/servicelists/example_rev1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ServiceList xmlns="urn:dvb:metadata:servicediscovery:2020" xmlns:mpeg7="urn:tva:mpeg7:2008" xmlns:tva="urn:tva:metadata:2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="45" xsi:schemaLocation="urn:dvb:metadata:servicediscovery:2020 ../dvbi_v2.0.xsd">
-  <Name>DVB-I Reference app rev.1 example</Name>
+  <Name>DVB-I Reference app availability example</Name>
   <ProviderName>DVB</ProviderName>
   <LCNTableList>
     <LCNTable>
@@ -11,13 +11,13 @@
   <ContentGuideSource CGSID="cgid-1">
     <ProviderName>DVB-I Reference Application</ProviderName>
     <ScheduleInfoEndpoint contentType="application/xml">
-      <URI>INSTALL--LOCATION/backend/schedule.php</URI>
+      <URI>INSTAL~~LOCATION/backend/schedule.php</URI>
     </ScheduleInfoEndpoint>
     <ProgramInfoEndpoint contentType="application/xml">
-      <URI>INSTALL--LOCATION/backend/program_information.php</URI>
+      <URI>INSTALL~~LOCATION/backend/program_information.php</URI>
     </ProgramInfoEndpoint>
     <MoreEpisodesEndpoint contentType="application/xml">
-      <URI>INSTALL--LOCATION/backend/more_episodes.php</URI>
+      <URI>INSTALL~~LOCATION/backend/more_episodes.php</URI>
     </MoreEpisodesEndpoint>
   </ContentGuideSource>
   <Service version="1">
@@ -41,7 +41,7 @@
     <RelatedMaterial>
       <HowRelated href="urn:dvb:metadata:cs:HowRelatedCS:2020:1000.1"></HowRelated>
       <MediaLocator>
-        <tva:MediaUri contentType="image/png">INSTALL--LOCATION/backend/channel_icons/outofservice_example.png</tva:MediaUri>
+        <tva:MediaUri contentType="image/png">INSTALL~~LOCATION/backend/channel_icons/outofservice_example.png</tva:MediaUri>
       </MediaLocator>
     </RelatedMaterial>
     <ServiceType href="urn:dvb:metadata:cs:ServiceTypeCS:2019:linear"></ServiceType>

--- a/backend/slepr-master.xml
+++ b/backend/slepr-master.xml
@@ -76,7 +76,7 @@
 			</sld:ServiceListURI>
 		</sld:ServiceListOffering>
     <sld:ServiceListOffering regulatorListFlag="false">
-    <sld:ServiceListName>DVB-I Reference Client rev.1 service list</sld:ServiceListName>
+    <sld:ServiceListName>DVB-I Reference Client Availability service list</sld:ServiceListName>
 			<sld:ServiceListURI contentType="application/xml">
 				<dvbisd:URI>INSTALL~~LOCATION/backend/servicelist.php?list=example_rev1.xml</dvbisd:URI>
 			</sld:ServiceListURI>

--- a/frontend/configuration.js
+++ b/frontend/configuration.js
@@ -1,5 +1,5 @@
 // DVB-I Reference installation location -- also backend/configuration.php
-var INSTALL_LOCATION = "https://stage.sofiadigital.fi/dvb/dvb-i-reference-application";
+var INSTALL_LOCATION = "http://paulhiggs.ddns.net:8877/pauls";
 
 // set to true to include <Service> channels that are not included in the selected LCN table.
-var INCLUDE_NON_LCN_CHANNELS = true;
+var INCLUDE_NON_LCN_CHANNELS = false;


### PR DESCRIPTION
Remove any services from LCN tables and set `INCLUDE_NON_LCN_CHANNELS = false` in `frontend/configuration.js` to avoid displaying any services that are non-functional