### PR TITLE
changed service list names to be more indicative of which is the default

### DIFF
--- a/backend/slepr-master.xml
+++ b/backend/slepr-master.xml
@@ -64,9 +64,10 @@
 			<sld:TargetCountry>GBR</sld:TargetCountry>
 		</sld:ServiceListOffering>
 	</sld:ProviderOffering>
-	<sld:ProviderOffering>
+	
+		<sld:ProviderOffering>
 		<sld:Provider>
-			<sld:Name>DVB</sld:Name>
+			<sld:Name>DVB default list</sld:Name>
 			<sld:Address>
 				<mpeg7:Name>DVB-I contact</mpeg7:Name>
 				<mpeg7:PostalAddress>
@@ -89,6 +90,24 @@
 				<sld:DVBTDelivery/>
 			</sld:Delivery>
 		</sld:ServiceListOffering>
+
+	</sld:ProviderOffering>
+	
+	<sld:ProviderOffering>
+		<sld:Provider>
+			<sld:Name>DVB</sld:Name>
+			<sld:Address>
+				<mpeg7:Name>DVB-I contact</mpeg7:Name>
+				<mpeg7:PostalAddress>
+					<mpeg7:AddressLine>Geneva, Switzerland</mpeg7:AddressLine>
+				</mpeg7:PostalAddress>
+			</sld:Address>
+			<sld:ElectronicAddress>
+				<mpeg7:Telephone>+41 22 7100000</mpeg7:Telephone>
+				<mpeg7:Email>dvb@dvb.org</mpeg7:Email>
+			</sld:ElectronicAddress>
+		</sld:Provider>
+
     <sld:ServiceListOffering regulatorListFlag="false">
     <sld:ServiceListName>Availability Windows service list</sld:ServiceListName>
 			<sld:ServiceListURI contentType="application/xml">

--- a/backend/slepr-master.xml
+++ b/backend/slepr-master.xml
@@ -99,7 +99,7 @@
 			</sld:Delivery>
 		</sld:ServiceListOffering>
 		<sld:ServiceListOffering regulatorListFlag="false">
-		<sld:ServiceListName>DDRM service list</sld:ServiceListName>
+		<sld:ServiceListName>DRM service list</sld:ServiceListName>
 			<sld:ServiceListURI contentType="application/xml">
 				<dvbisd:URI>INSTALL~~LOCATION/backend/servicelist.php?list=drm.xml</dvbisd:URI>
 			</sld:ServiceListURI>

--- a/backend/slepr-master.xml
+++ b/backend/slepr-master.xml
@@ -21,50 +21,7 @@
 			<mpeg7:Email>dvb@dvb.org</mpeg7:Email>
 		</sld:ElectronicAddress>
 	</sld:ServiceListRegistryEntity>
-	<sld:ProviderOffering>
-		<sld:Provider>
-			<sld:Name>SES</sld:Name>
-			<sld:Address>
-				<mpeg7:Name>Jan</mpeg7:Name>
-				<mpeg7:PostalAddress>
-					<mpeg7:AddressLine>Luxembourg</mpeg7:AddressLine>
-				</mpeg7:PostalAddress>
-			</sld:Address>
-			<sld:ElectronicAddress>
-				<mpeg7:Telephone>+352 00000000</mpeg7:Telephone>
-				<mpeg7:Email>dvb-i@ses.com</mpeg7:Email>
-			</sld:ElectronicAddress>
-		</sld:Provider>
-		<sld:ServiceListOffering>
-			<sld:ServiceListName>ASTRA 19.2 E</sld:ServiceListName>
-			<sld:ServiceListURI contentType="application/xml">
-				<dvbisd:URI>
-					https://www.satip.info/sites/satip/files/files/ASTRA_19_2_E.xml
-				</dvbisd:URI>
-			</sld:ServiceListURI>
-			<sld:Delivery>
-				<sld:DVBSDelivery>
-					<sld:OrbitalPosition>19.2</sld:OrbitalPosition>
-				</sld:DVBSDelivery>
-			</sld:Delivery>
-			<sld:TargetCountry>DEU</sld:TargetCountry>
-		</sld:ServiceListOffering>
-    <sld:ServiceListOffering>
-			<sld:ServiceListName>ASTRA 28.2 E</sld:ServiceListName>
-			<sld:ServiceListURI contentType="application/xml">
-				<dvbisd:URI>
-					https://www.satip.info/sites/satip/files/files/ASTRA_28_2_E.xml
-				</dvbisd:URI>
-			</sld:ServiceListURI>
-			<sld:Delivery>
-				<sld:DVBSDelivery>
-					<sld:OrbitalPosition>28.2</sld:OrbitalPosition>
-				</sld:DVBSDelivery>
-			</sld:Delivery>
-			<sld:TargetCountry>GBR</sld:TargetCountry>
-		</sld:ServiceListOffering>
-	</sld:ProviderOffering>
-	
+
 		<sld:ProviderOffering>
 		<sld:Provider>
 			<sld:Name>DVB default list</sld:Name>
@@ -92,7 +49,7 @@
 		</sld:ServiceListOffering>
 
 	</sld:ProviderOffering>
-	
+
 	<sld:ProviderOffering>
 		<sld:Provider>
 			<sld:Name>DVB</sld:Name>
@@ -180,4 +137,49 @@
 			</sld:Delivery>
 		</sld:ServiceListOffering>
 	</sld:ProviderOffering>
+
+  	<sld:ProviderOffering>
+		<sld:Provider>
+			<sld:Name>SES</sld:Name>
+			<sld:Address>
+				<mpeg7:Name>Jan</mpeg7:Name>
+				<mpeg7:PostalAddress>
+					<mpeg7:AddressLine>Luxembourg</mpeg7:AddressLine>
+				</mpeg7:PostalAddress>
+			</sld:Address>
+			<sld:ElectronicAddress>
+				<mpeg7:Telephone>+352 00000000</mpeg7:Telephone>
+				<mpeg7:Email>dvb-i@ses.com</mpeg7:Email>
+			</sld:ElectronicAddress>
+		</sld:Provider>
+		<sld:ServiceListOffering>
+			<sld:ServiceListName>ASTRA 19.2 E</sld:ServiceListName>
+			<sld:ServiceListURI contentType="application/xml">
+				<dvbisd:URI>
+					https://www.satip.info/sites/satip/files/files/ASTRA_19_2_E.xml
+				</dvbisd:URI>
+			</sld:ServiceListURI>
+			<sld:Delivery>
+				<sld:DVBSDelivery>
+					<sld:OrbitalPosition>19.2</sld:OrbitalPosition>
+				</sld:DVBSDelivery>
+			</sld:Delivery>
+			<sld:TargetCountry>DEU</sld:TargetCountry>
+		</sld:ServiceListOffering>
+    <sld:ServiceListOffering>
+			<sld:ServiceListName>ASTRA 28.2 E</sld:ServiceListName>
+			<sld:ServiceListURI contentType="application/xml">
+				<dvbisd:URI>
+					https://www.satip.info/sites/satip/files/files/ASTRA_28_2_E.xml
+				</dvbisd:URI>
+			</sld:ServiceListURI>
+			<sld:Delivery>
+				<sld:DVBSDelivery>
+					<sld:OrbitalPosition>28.2</sld:OrbitalPosition>
+				</sld:DVBSDelivery>
+			</sld:Delivery>
+			<sld:TargetCountry>GBR</sld:TargetCountry>
+		</sld:ServiceListOffering>
+	</sld:ProviderOffering>
+
 </sld:ServiceListEntryPoints>

--- a/backend/slepr-master.xml
+++ b/backend/slepr-master.xml
@@ -79,8 +79,8 @@
 			</sld:ElectronicAddress>
 		</sld:Provider>
 		<sld:ServiceListOffering regulatorListFlag="false">
-		<sld:ServiceListName>DVB-I Reference Client service list</sld:ServiceListName>
-		<sld:ServiceListName xml:lang="zh">DVB-I 参考客户端服务列表</sld:ServiceListName>
+		<sld:ServiceListName>DVB-I Reference Client default service list</sld:ServiceListName>
+		<sld:ServiceListName xml:lang="zh">DVB-I 参考客户端默认服务列表</sld:ServiceListName>
 			<sld:ServiceListURI contentType="application/xml">
 				<dvbisd:URI>INSTALL~~LOCATION/backend/servicelist.php?list=example.xml</dvbisd:URI>
 			</sld:ServiceListURI>
@@ -90,7 +90,7 @@
 			</sld:Delivery>
 		</sld:ServiceListOffering>
     <sld:ServiceListOffering regulatorListFlag="false">
-    <sld:ServiceListName>DVB-I Reference Client Availability service list</sld:ServiceListName>
+    <sld:ServiceListName>Availability Windows service list</sld:ServiceListName>
 			<sld:ServiceListURI contentType="application/xml">
 				<dvbisd:URI>INSTALL~~LOCATION/backend/servicelist.php?list=example_availability.xml</dvbisd:URI>
 			</sld:ServiceListURI>
@@ -99,7 +99,7 @@
 			</sld:Delivery>
 		</sld:ServiceListOffering>
 		<sld:ServiceListOffering regulatorListFlag="false">
-		<sld:ServiceListName>DVB-I Reference Client DRM service list</sld:ServiceListName>
+		<sld:ServiceListName>DDRM service list</sld:ServiceListName>
 			<sld:ServiceListURI contentType="application/xml">
 				<dvbisd:URI>INSTALL~~LOCATION/backend/servicelist.php?list=drm.xml</dvbisd:URI>
 			</sld:ServiceListURI>
@@ -126,7 +126,7 @@
 			</sld:Delivery>
 		</sld:ServiceListOffering>
 		<sld:ServiceListOffering regulatorListFlag="false">
-		  <sld:ServiceListName>Service prominence list(r6)</sld:ServiceListName>
+		  <sld:ServiceListName>Service prominence list</sld:ServiceListName>
 			<sld:ServiceListURI contentType="application/xml">
 				<dvbisd:URI>INSTALL~~LOCATION/backend/servicelist.php?list=prominence_r6.xml</dvbisd:URI>
 			</sld:ServiceListURI>

--- a/frontend/android/styles/dvbi.css
+++ b/frontend/android/styles/dvbi.css
@@ -452,3 +452,8 @@ body.player {
 .ranking_10000 {
   background-color: #0000ff30;
 }
+
+#servicelists h4 {
+  margin-block-start: 0.6rem;
+  margin-block-end: 0.1rem;
+}


### PR DESCRIPTION
for issue #82.

Service lists renamed as follows:
![image](https://github.com/DVBProject/DVB-I-Reference-Client/assets/3158807/71e2a6a8-0afb-41ee-98dd-2fc3bd8bd9d8)
